### PR TITLE
Add binary analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
+ "goblin",
 ]
 
 [[package]]
@@ -144,6 +145,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "goblin"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27c1b4369c2cd341b5de549380158b105a04c331be5db9110eef7b6d2742134"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +166,18 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
@@ -178,6 +202,26 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ name = "cargo-analyze"
 anyhow = "1.0.75"
 cargo_metadata = "0.18.0"
 clap = { version = "4.4.6", features = ["derive"] }
+goblin = "0.7.1"

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -4,21 +4,19 @@ use anyhow::{anyhow, Context};
 use goblin::mach::Mach;
 use goblin::Object;
 
-pub fn analyze(filepath: &Path) -> Result<(), anyhow::Error> {
+pub fn analyze(filepath: &Path) -> Result<Vec<String>, anyhow::Error> {
     let buffer = std::fs::read(filepath)
         .with_context(|| format!("Failed to read file at {} to buffer", filepath.display()))?;
     let object = Object::parse(&buffer).context("Failed to parse buffer as goblin object")?;
 
     match object {
         Object::Elf(elf) => {
-            println!("Elf");
-            println!("Libs: {:#?}", elf.libraries);
-            Ok(())
+            let libs = elf.libraries.into_iter().map(ToOwned::to_owned).collect();
+            Ok(libs)
         }
         Object::Mach(Mach::Binary(mach)) => {
-            println!("Binary mach");
-            println!("Libs: {:#?}", mach.libs);
-            Ok(())
+            let libs = mach.libs.into_iter().map(ToOwned::to_owned).collect();
+            Ok(libs)
         }
         //
         // --------------------------

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -1,0 +1,35 @@
+use std::path::Path;
+
+use anyhow::{anyhow, Context};
+use goblin::mach::Mach;
+use goblin::Object;
+
+pub fn analyze(filepath: &Path) -> Result<(), anyhow::Error> {
+    let buffer = std::fs::read(filepath)
+        .with_context(|| format!("Failed to read file at {} to buffer", filepath.display()))?;
+    let object = Object::parse(&buffer).context("Failed to parse buffer as goblin object")?;
+
+    match object {
+        Object::Elf(elf) => {
+            println!("Elf");
+            println!("Libs: {:#?}", elf.libraries);
+            Ok(())
+        }
+        Object::Mach(Mach::Binary(mach)) => {
+            println!("Binary mach");
+            println!("Libs: {:#?}", mach.libs);
+            Ok(())
+        }
+        //
+        // --------------------------
+        //
+        Object::PE(_) => Err(anyhow!("Object was unexpected goblin object of type `PE`")),
+        Object::Mach(Mach::Fat(_)) => Err(anyhow!(
+            "Object was unexpected goblin object of type `Fat mach`"
+        )),
+        Object::Archive(_) => Err(anyhow!(
+            "Object was unexpected goblin object of type `Archive`"
+        )),
+        Object::Unknown(_) => Err(anyhow!("Object was unknown goblin object")),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,6 @@ impl Display for LinkedLibs {
             return Ok(());
         }
 
-        writeln!(f, "Linked libraries:")?;
-
         for (key, val) in self.known.iter() {
             writeln!(f, "{key}: {}", set_to_string(val))?;
         }
@@ -122,7 +120,7 @@ fn set_to_string<T: Display>(set: &BTreeSet<T>) -> String {
 
     let mut s = String::from("{ ");
 
-    while let Some(item) = iter.next() {
+    for item in iter {
         s += &format!("{prev}, ");
         prev = item;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ use cargo_metadata::camino::Utf8PathBuf;
 use cargo_metadata::BuildScript;
 use cargo_metadata::Message;
 
+pub mod binary;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum LibraryType {
     Static,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), anyhow::Error> {
         .manifest_path
         .clone()
         .map(|path| vec![OsString::from("--manifest-path"), path.into_os_string()])
-        .unwrap_or_else(Vec::new);
+        .unwrap_or_default();
 
     let output = Command::new("cargo")
         .arg("build")
@@ -39,7 +39,8 @@ fn main() -> Result<(), anyhow::Error> {
 
     if cli.inspect_binary {
         for executable in metadata.executables {
-            cargo_analyze::binary::analyze(executable.as_std_path())?;
+            let libs = cargo_analyze::binary::analyze(executable.as_std_path())?;
+            println!("{libs:#?}");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,11 +37,12 @@ fn main() -> Result<(), anyhow::Error> {
     let metadata = Metadata::from_reader(reader);
     println!("{}", metadata.linked_libs);
 
-    if cli.verbose {
+    if cli.inspect_binary {
         for executable in metadata.executables {
-            println!("Path to executable: {executable}");
+            cargo_analyze::binary::analyze(executable.as_std_path())?;
         }
     }
+
     Ok(())
 }
 
@@ -64,6 +65,6 @@ struct Cli {
     #[arg(long)]
     manifest_path: Option<PathBuf>,
 
-    #[arg(short, long, default_value_t = false)]
-    verbose: bool,
+    #[arg(long, default_value_t = false)]
+    inspect_binary: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use std::ffi::OsString;
-use std::io::BufReader;
+use std::ffi::OsStr;
+use std::io::{BufReader, Write};
 use std::path::PathBuf;
 use std::process::Command;
 use std::process::Stdio;
@@ -10,13 +10,12 @@ use clap::Parser;
 use cargo_analyze::Metadata;
 
 fn main() -> Result<(), anyhow::Error> {
-    let cli = parse();
+    let cli = Cli::parse();
 
-    let extra_args = cli
-        .manifest_path
-        .clone()
-        .map(|path| vec![OsString::from("--manifest-path"), path.into_os_string()])
-        .unwrap_or_default();
+    let extra_args = match &cli.manifest_path {
+        Some(path) => vec![OsStr::new("--manifest-path"), path.as_os_str()],
+        None => Vec::new(),
+    };
 
     let output = Command::new("cargo")
         .arg("build")
@@ -29,43 +28,64 @@ fn main() -> Result<(), anyhow::Error> {
         .context("failed whilst waiting for `cargo build`")?;
 
     if !output.status.success() {
-        let msg = anyhow!("`cargo build` failed: {}", output.status);
-        return Err(msg);
+        return Err(anyhow!("`cargo build` failed: {}", output.status));
     }
 
     let reader = BufReader::new(&output.stdout[..]);
     let metadata = Metadata::from_reader(reader);
-    println!("{}", metadata.linked_libs);
 
-    if cli.inspect_binary {
-        for executable in metadata.executables {
-            let libs = cargo_analyze::binary::analyze(executable.as_std_path())?;
-            println!("{libs:#?}");
+    // Makeshift `try`-block
+    || -> Result<(), anyhow::Error> {
+        let mut stdout = std::io::stdout().lock();
+
+        stdout.write_all(b"Libraries linked by rustc:\n")?;
+        writeln!(stdout, "{}", metadata.linked_libs)?;
+
+        if !cli.ignore_binary_analysis {
+            for executable in &metadata.executables {
+                let mut libs = cargo_analyze::binary::analyze(executable.as_std_path())?;
+                libs.sort_unstable();
+                libs.retain(|e| e != "self");
+
+                let filename = executable
+                    .file_name()
+                    .expect("Failed to get filename of executable");
+                writeln!(stdout, "Libraries linked to executable `{filename}`:")?;
+
+                for lib in libs {
+                    writeln!(stdout, " - {lib}")?;
+                }
+            }
         }
-    }
+
+        Ok(())
+    }()
+    .expect("Failed to write to standard output");
 
     Ok(())
-}
-
-fn parse() -> Cli {
-    let mut args: Vec<String> = std::env::args().collect();
-
-    // Strip extra `analyze`, if invoked via cargo:
-    // `cargo-analyze ...` -> ["cargo-analyze", ...]
-    // `cargo analyze ...` -> ["cargo-analyze", "analyze", ...]
-    if args.get(1).map(String::as_str) == Some("analyze") {
-        args.remove(1);
-    }
-
-    Cli::parse_from(args)
 }
 
 #[derive(Debug, Parser)]
 #[command(bin_name = "cargo")]
 struct Cli {
-    #[arg(long)]
+    #[arg(long, value_name = "PATH")]
     manifest_path: Option<PathBuf>,
 
     #[arg(long, default_value_t = false)]
-    inspect_binary: bool,
+    ignore_binary_analysis: bool,
+}
+
+impl Cli {
+    fn parse() -> Cli {
+        let mut args: Vec<String> = std::env::args().collect();
+
+        // Strip extra `analyze`, if invoked via cargo:
+        // `cargo-analyze ...` -> ["cargo-analyze", ...]
+        // `cargo analyze ...` -> ["cargo-analyze", "analyze", ...]
+        if args.get(1).map(String::as_str) == Some("analyze") {
+            args.remove(1);
+        }
+
+        Cli::parse_from(args)
+    }
 }


### PR DESCRIPTION
Executables are inspected in order to discern what libraries they dynamically link to. The feature can be turned off with the `--ignore-binary-analysis` flag.